### PR TITLE
(maint) Add a DeviceSpin task

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,4 +3,5 @@
 ---
 fixtures:
   forge_modules:
+    task_helper: "puppetlabs-ruby_task_helper"
 #     stdlib: "puppetlabs/stdlib"

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,5 +1,8 @@
 ---
 Gemfile:
+  required:
+    ':test':
+      - gem: 'bolt'
   optional:
     ':development':
       - gem: 'puppet-resource_api'

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ group :development do
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-resource_api",                           require: false
 end
+group :test do
+  gem "bolt", require: false
+end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
 facter_version = ENV['FACTER_GEM_VERSION']

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ This module contains a test device that only burns CPU and wall clock time to be
 
 Configure an arbitrary amount of devices using the `spinner` type in your `device.conf`. Inthe credentials you can configure extra wait times for fetching facts and retrieving resources as `facts_cpu_time`, `facts_wait_time`, `get_cpu_time` and `get_wait_time`. All times can be specified in fractional seconds.
 
+### Requirement for executing task
+
+The [puppetlabs-ruby_task_helper](https://forge.puppet.com/puppetlabs/ruby_task_helper) module should be installed
+
 ## Usage
 
 * Create a catalog with an appropriate number of `spinner` resources in it.
@@ -27,6 +31,36 @@ Configure an arbitrary amount of devices using the `spinner` type in your `devic
 * Run `puppet device` to execute those catalogs.
 * ???
 * Profit!
+
+### Executing task
+
+The `device_spin` task can be executed from bolt by supplying in an inventory file:
+
+*  A proxy puppet server
+* `name` Name of the device
+* `alias` Alias to use for the device
+* `config` of which:
+  * `transport` Always `remote`
+  * `remote` Credentials of the device, of which
+    * `cpu_time` CPU time to spin
+    * `wait_time` Wait time to spin
+
+For example:
+
+```
+nodes:
+    - name: spinny.puppetlabs.net
+      alias: spinny
+      config:
+        transport: remote
+        remote:
+          cpu_time: 2
+          wait_time: 3
+```
+
+Bolt executes the task with the following command:
+
+`bolt task run test_device::device_spin --nodes spinny --modulepath /etc/puppetlabs/code/environments/production/modules/ --inventoryfile ./inventory.yaml`
 
 ## Limitations
 

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,9 @@
     {
       "name": "puppet",
       "version_requirement": ">= 4.10.0 < 7.0.0"
+    },
+    {
+      "name": "puppetlabs-ruby_task_helper"
     }
   ],
   "pdk-version": "1.10.0",

--- a/spec/unit/tasks/device_spin_spec.rb
+++ b/spec/unit/tasks/device_spin_spec.rb
@@ -1,0 +1,48 @@
+require 'puppet'
+require_relative '../../fixtures/modules/ruby_task_helper/files/task_helper.rb'
+require_relative '../../../lib/puppet/util/network_device/spinner/device'
+require_relative '../../../tasks/device_spin'
+
+# An example of testing a task using the helper
+
+describe 'DeviceSpin task' do
+  it 'runs device spin successfully with correct inputs' do
+    allow(STDIN).to receive(:read)
+      .and_return('{"_task":"test_device::device_spin", "_target":{"run-on":"localhost", "cpu_time":2, "wait_time":3,'\
+                  '"name":"spinny.puppetlabs.net", "uri":"spinny.puppetlabs.net", "protocol":"remote", "host":"spinny.puppetlabs.net"}}')
+    expect(STDOUT).to receive(:puts).with('{"status":"success","results":"spinner device spun: cpu_time 2, wait_time 3"}')
+    DeviceSpin.run
+  end
+
+  it 'returns error without cpu_time' do
+    allow(STDIN).to receive(:read)
+      .and_return('{"_task":"test_device::device_spin", "_target":{"run-on":"localhost", "wait_time":3,'\
+                  ' "name":"spinny.puppetlabs.net", "uri":"spinny.puppetlabs.net", "protocol":"remote", "host":"spinny.puppetlabs.net"}}')
+    expect(STDOUT).to receive(:puts).with("{\"_error\":{\"msg\":\"Parameter 'cpu_time' not found or contains illegal characters\",\"kind\":\"puppetlabs/spinner\",\"details\":{}}}")
+    DeviceSpin.run
+  end
+
+  it 'returns error with invalid cpu_time' do
+    allow(STDIN).to receive(:read)
+      .and_return('{"_task":"test_device::device_spin", "_target":{"run-on":"localhost", "cpu_time":"two", "wait_time":3,'\
+                  ' "name":"spinny.puppetlabs.net", "uri":"spinny.puppetlabs.net", "protocol":"remote", "host":"spinny.puppetlabs.net"}}')
+    expect(STDOUT).to receive(:puts).with("{\"_error\":{\"msg\":\"Parameter 'cpu_time' not found or contains illegal characters\",\"kind\":\"puppetlabs/spinner\",\"details\":{}}}")
+    DeviceSpin.run
+  end
+
+  it 'returns error without wait_time' do
+    allow(STDIN).to receive(:read)
+      .and_return('{"_task":"test_device::device_spin", "_target":{"run-on":"localhost",'\
+                  ' "cpu_time":2, "name":"spinny.puppetlabs.net", "uri":"spinny.puppetlabs.net", "protocol":"remote", "host":"spinny.puppetlabs.net"}}')
+    expect(STDOUT).to receive(:puts).with("{\"_error\":{\"msg\":\"Parameter 'wait_time' not found or contains illegal characters\",\"kind\":\"puppetlabs/spinner\",\"details\":{}}}")
+    DeviceSpin.run
+  end
+
+  it 'returns error with invalid wait_time' do
+    allow(STDIN).to receive(:read)
+      .and_return('{"_task":"test_device::device_spin", "_target":{"run-on":"localhost", "cpu_time":2, "wait_time":"three",'\
+                  ' "name":"spinny.puppetlabs.net", "uri":"spinny.puppetlabs.net", "protocol":"remote", "host":"spinny.puppetlabs.net"}}')
+    expect(STDOUT).to receive(:puts).with("{\"_error\":{\"msg\":\"Parameter 'wait_time' not found or contains illegal characters\",\"kind\":\"puppetlabs/spinner\",\"details\":{}}}")
+    DeviceSpin.run
+  end
+end

--- a/spec/unit/tasks/device_spin_spec.rb
+++ b/spec/unit/tasks/device_spin_spec.rb
@@ -1,48 +1,109 @@
 require 'puppet'
+require 'bolt_spec/run'
 require_relative '../../fixtures/modules/ruby_task_helper/files/task_helper.rb'
-require_relative '../../../lib/puppet/util/network_device/spinner/device'
-require_relative '../../../tasks/device_spin'
 
 # An example of testing a task using the helper
 
-describe 'DeviceSpin task' do
+def puppet_6_or_greater?
+  if Puppet.version.to_f >= 6.0 # Puppet 6 required for Bolt task execution
+    return true
+  end
+  false
+end
+
+RSpec.configure do |config|
+  # Do not run these specs on less than puppet 6
+  config.filter_run_excluding bypass_on_less_than_puppet_6: true unless puppet_6_or_greater?
+end
+
+describe 'DeviceSpin task', :bypass_on_less_than_puppet_6 do
+  let(:modulepath) { File.join(__dir__, '../../fixtures/modules') }
+
+  let(:bolt_config) do
+    { 'modulepath' => modulepath }
+  end
+
+  include BoltSpec::Run
   it 'runs device spin successfully with correct inputs' do
-    allow(STDIN).to receive(:read)
-      .and_return('{"_task":"test_device::device_spin", "_target":{"run-on":"localhost", "cpu_time":2, "wait_time":3,'\
-                  '"name":"spinny.puppetlabs.net", "uri":"spinny.puppetlabs.net", "protocol":"remote", "host":"spinny.puppetlabs.net"}}')
-    expect(STDOUT).to receive(:puts).with('{"status":"success","results":"spinner device spun: cpu_time 2, wait_time 3"}')
-    DeviceSpin.run
+    result = run_task('test_device::device_spin', 'spinny', {},
+                      inventory: { 'nodes' => [{
+                        'name' => 'spinny.puppetlabs.net',
+                        'alias' => 'spinny',
+                        'config' => {
+                          'transport' => 'remote',
+                          'remote' => {
+                            'cpu_time' => '2',
+                            'wait_time' => '3',
+                          },
+                        },
+                      }] })
+    expect(result[0]['status']).to eq('success')
+    expect(result[0]['result']['results']).to eq('spinner device spun: cpu_time 2, wait_time 3')
   end
 
   it 'returns error without cpu_time' do
-    allow(STDIN).to receive(:read)
-      .and_return('{"_task":"test_device::device_spin", "_target":{"run-on":"localhost", "wait_time":3,'\
-                  ' "name":"spinny.puppetlabs.net", "uri":"spinny.puppetlabs.net", "protocol":"remote", "host":"spinny.puppetlabs.net"}}')
-    expect(STDOUT).to receive(:puts).with("{\"_error\":{\"msg\":\"Parameter 'cpu_time' not found or contains illegal characters\",\"kind\":\"puppetlabs/spinner\",\"details\":{}}}")
-    DeviceSpin.run
+    result = run_task('test_device::device_spin', 'spinny', {},
+                      inventory: { 'nodes' => [{
+                        'name' => 'spinny.puppetlabs.net',
+                        'alias' => 'spinny',
+                        'config' => {
+                          'transport' => 'remote',
+                          'remote' => {
+                            'wait_time' => '3',
+                          },
+                        },
+                      }] })
+    expect(result[0]['status']).to eq('failure')
+    expect(result[0]['result']['_error']['msg']).to eq("Parameter 'cpu_time' not found or contains illegal characters")
   end
 
   it 'returns error with invalid cpu_time' do
-    allow(STDIN).to receive(:read)
-      .and_return('{"_task":"test_device::device_spin", "_target":{"run-on":"localhost", "cpu_time":"two", "wait_time":3,'\
-                  ' "name":"spinny.puppetlabs.net", "uri":"spinny.puppetlabs.net", "protocol":"remote", "host":"spinny.puppetlabs.net"}}')
-    expect(STDOUT).to receive(:puts).with("{\"_error\":{\"msg\":\"Parameter 'cpu_time' not found or contains illegal characters\",\"kind\":\"puppetlabs/spinner\",\"details\":{}}}")
-    DeviceSpin.run
+    result = run_task('test_device::device_spin', 'spinny', {},
+                      inventory: { 'nodes' => [{
+                        'name' => 'spinny.puppetlabs.net',
+                        'alias' => 'spinny',
+                        'config' => {
+                          'transport' => 'remote',
+                          'remote' => {
+                            'cpu_time' => 'two',
+                            'wait_time' => '3',
+                          },
+                        },
+                      }] })
+    expect(result[0]['status']).to eq('failure')
+    expect(result[0]['result']['_error']['msg']).to eq("Parameter 'cpu_time' not found or contains illegal characters")
   end
 
   it 'returns error without wait_time' do
-    allow(STDIN).to receive(:read)
-      .and_return('{"_task":"test_device::device_spin", "_target":{"run-on":"localhost",'\
-                  ' "cpu_time":2, "name":"spinny.puppetlabs.net", "uri":"spinny.puppetlabs.net", "protocol":"remote", "host":"spinny.puppetlabs.net"}}')
-    expect(STDOUT).to receive(:puts).with("{\"_error\":{\"msg\":\"Parameter 'wait_time' not found or contains illegal characters\",\"kind\":\"puppetlabs/spinner\",\"details\":{}}}")
-    DeviceSpin.run
+    result = run_task('test_device::device_spin', 'spinny', {},
+                      inventory: { 'nodes' => [{
+                        'name' => 'spinny.puppetlabs.net',
+                        'alias' => 'spinny',
+                        'config' => {
+                          'transport' => 'remote',
+                          'remote' => {
+                            'cpu_time' => '2',
+                          },
+                        },
+                      }] })
+    expect(result[0]['status']).to eq('failure')
+    expect(result[0]['result']['_error']['msg']).to eq("Parameter 'wait_time' not found or contains illegal characters")
   end
 
   it 'returns error with invalid wait_time' do
-    allow(STDIN).to receive(:read)
-      .and_return('{"_task":"test_device::device_spin", "_target":{"run-on":"localhost", "cpu_time":2, "wait_time":"three",'\
-                  ' "name":"spinny.puppetlabs.net", "uri":"spinny.puppetlabs.net", "protocol":"remote", "host":"spinny.puppetlabs.net"}}')
-    expect(STDOUT).to receive(:puts).with("{\"_error\":{\"msg\":\"Parameter 'wait_time' not found or contains illegal characters\",\"kind\":\"puppetlabs/spinner\",\"details\":{}}}")
-    DeviceSpin.run
+    result = run_task('test_device::device_spin', 'spinny', {},
+                      inventory: { 'nodes' => [{
+                        'name' => 'spinny.puppetlabs.net',
+                        'alias' => 'spinny',
+                        'config' => {
+                          'transport' => 'remote',
+                          'remote' => {
+                            'cpu_time' => '2',
+                            'wait_time' => 'three',
+                          },
+                        },
+                      }] })
+    expect(result[0]['status']).to eq('failure')
+    expect(result[0]['result']['_error']['msg']).to eq("Parameter 'wait_time' not found or contains illegal characters")
   end
 end

--- a/tasks/device_spin.json
+++ b/tasks/device_spin.json
@@ -3,7 +3,11 @@
   "description": "Spin the device",
   "remote": true,
   "supports_noop": false,
+  "input_method": "stdin",
   "parameters": {
   },
-  "files": ["ruby_task_helper/files/task_helper.rb"]
+  "files": [
+    "ruby_task_helper/files/task_helper.rb",
+    "test_device/lib/puppet/util/network_device/spinner/device.rb"
+  ]
 }

--- a/tasks/device_spin.json
+++ b/tasks/device_spin.json
@@ -1,0 +1,9 @@
+{
+  "puppet_task_version": 1,
+  "description": "Spin the device",
+  "remote": true,
+  "supports_noop": false,
+  "parameters": {
+  },
+  "files": ["ruby_task_helper/files/task_helper.rb"]
+}

--- a/tasks/device_spin.rb
+++ b/tasks/device_spin.rb
@@ -1,0 +1,76 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require 'puppet'
+require 'puppet/util/network_device/config'
+
+def require_module_file(file)
+  return unless File.exist?("#{Puppet[:plugindest]}/#{file}.rb")
+  require "#{Puppet[:plugindest]}/#{file}"
+end
+
+installdir_path = '../../ruby_task_helper/files/task_helper.rb'
+local_path = '../files/task_helper.rb'
+
+# Task is being run with bolt and helper is at location relative to task
+if File.exist?(File.join(File.dirname(__FILE__), installdir_path))
+  require_relative installdir_path
+elsif File.exist?(File.join(File.dirname(__FILE__), local_path))
+  require_relative local_path
+end
+
+# validate values.
+def validate_parameters(cpu_time, wait_time)
+  raise("Parameter 'cpu_time' not found or contains illegal characters") unless safe_int?(cpu_time)
+  raise("Parameter 'wait_time' not found or contains illegal characters") unless safe_int?(wait_time)
+end
+
+# Similar with ints
+def safe_int?(param)
+  if param.nil?
+    return false
+  end
+  Integer(param)
+rescue
+  false
+end
+
+# Return an error
+def return_error(message)
+  result = {}
+  result[:_error] = {
+    msg:     message,
+    kind:    'puppetlabs/spinner',
+    details: {},
+  }
+  puts result.to_json
+end
+
+# Return a result
+def return_success(message)
+  result = {}
+  result[:status]  = 'success'
+  result[:results] = message
+  puts result.to_json
+end
+
+# Class for the DeviceSpin task
+# Requires target in inventory set with CPU time and Wait time parameters
+class DeviceSpin < TaskHelper
+  def task(params)
+    unless Puppet.settings.global_defaults_initialized?
+      Puppet.initialize_settings
+    end
+    require_module_file('puppet/util/network_device/spinner/device')
+    validate_parameters(params[:_target][:cpu_time], params[:_target][:wait_time])
+    spinner_device = Puppet::Util::NetworkDevice::Spinner::Device.new(params[:_target])
+    spinner_device.spin(params[:_target][:cpu_time].to_i, params[:_target][:wait_time].to_i)
+    return_success("spinner device spun: cpu_time #{params[:_target][:cpu_time].to_i}, wait_time #{params[:_target][:wait_time].to_i}")
+  rescue StandardError => e
+    config_save_error = e.message
+    return_error(config_save_error)
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  DeviceSpin.run
+end

--- a/tasks/device_spin.rb
+++ b/tasks/device_spin.rb
@@ -1,8 +1,8 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 
 require 'puppet'
-require_relative "../../ruby_task_helper/files/task_helper.rb"
-require_relative "../../test_device/lib/puppet/util/network_device/spinner/device.rb"
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+require_relative '../../test_device/lib/puppet/util/network_device/spinner/device.rb'
 
 # validate values.
 def validate_parameters(cpu_time, wait_time)

--- a/tasks/device_spin.rb
+++ b/tasks/device_spin.rb
@@ -1,22 +1,8 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 
 require 'puppet'
-require 'puppet/util/network_device/config'
-
-def require_module_file(file)
-  return unless File.exist?("#{Puppet[:plugindest]}/#{file}.rb")
-  require "#{Puppet[:plugindest]}/#{file}"
-end
-
-installdir_path = '../../ruby_task_helper/files/task_helper.rb'
-local_path = '../files/task_helper.rb'
-
-# Task is being run with bolt and helper is at location relative to task
-if File.exist?(File.join(File.dirname(__FILE__), installdir_path))
-  require_relative installdir_path
-elsif File.exist?(File.join(File.dirname(__FILE__), local_path))
-  require_relative local_path
-end
+require_relative "../../ruby_task_helper/files/task_helper.rb"
+require_relative "../../test_device/lib/puppet/util/network_device/spinner/device.rb"
 
 # validate values.
 def validate_parameters(cpu_time, wait_time)
@@ -60,7 +46,6 @@ class DeviceSpin < TaskHelper
     unless Puppet.settings.global_defaults_initialized?
       Puppet.initialize_settings
     end
-    require_module_file('puppet/util/network_device/spinner/device')
     validate_parameters(params[:_target][:cpu_time], params[:_target][:wait_time])
     spinner_device = Puppet::Util::NetworkDevice::Spinner::Device.new(params[:_target])
     spinner_device.spin(params[:_target][:cpu_time].to_i, params[:_target][:wait_time].to_i)


### PR DESCRIPTION
This will allow for task workflows to be tested without requiring an actual device